### PR TITLE
Update index.html, fix to could view it online for reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,15 @@
     <title>suitepicon</title>
     <style>
 
+        @font-face {
+            font-family: "suitepicon";
+            src: url("suitepicon.eot") format("embedded-opentype"),
+                 url("./suitepicon/suitepicon.woff2") format("woff2"),
+                 url("./suitepicon/suitepicon.woff") format("woff"),
+                 url("./suitepicon/suitepicon.ttf") format("truetype"),
+                 url("./suitepicon/suitepicon.svg#suitepicon") format("svg");
+        }
+
         body {
             font-family: sans-serif;
             margin: 0;
@@ -29,6 +38,9 @@
         }
 
         .preview .inner i {
+            font-family: "suitepicon";
+            font-style: normal !important;
+            font-weight: normal !important;
             line-height: 85px;
             font-size: 40px;
             color: #333;


### PR DESCRIPTION
Update index.html, fix to could view it online for reference

On documentation ther is a link for icon preview: https://docs.suitecrm.com/developer/theme/suitepiconsfont/create_suitepicon_font/, but if you follow it, icons are not showed because missing font. This fix is requested in order to could have it available for reference.

It could be ddone also adding <link rel="stylesheet" href="suitepicon/suitepicon-glyphs.scss"> to head section, but this only work if I also change all urls of @font-face prefixing with "./" in order to get relative paths. Since I don't tested if this will break the generation of final stylesheet, I have opted to embed it.

Regards.